### PR TITLE
Try to remove scope prototype on firewall context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin
 composer.lock
 vendor
+features/bootstrap/app/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,12 @@ php:
 install:
     - composer install --dev --prefer-source
 
+before_script:
+    - php -S localhost:8888 -t features/bootstrap/web 2> /dev/null &
+
 script:
     - bin/atoum
+    - bin/behat -f progress
 
 notifications:
     email:

--- a/DependencyInjection/RezzzaSecurityExtension.php
+++ b/DependencyInjection/RezzzaSecurityExtension.php
@@ -47,7 +47,7 @@ class RezzzaSecurityExtension extends Extension
             $definition->addMethodCall('set', array('firewall.replay_protection', $data['replay_protection']));
             $definition->addMethodCall('set', array('firewall.algorithm', $data['algorithm']));
             $definition->addMethodCall('set', array('firewall.secret', $data['secret']));
-            $definition->setScope('prototype');
+            //$definition->setScope('prototype');
 
             $container->setDefinition($serviceName, $definition);
         }

--- a/Security/Firewall/RequestSignatureListener.php
+++ b/Security/Firewall/RequestSignatureListener.php
@@ -31,7 +31,7 @@ class RequestSignatureListener implements ListenerInterface
      * @param LoggerInterface                $logger                logger
      * @param RequestSignatureEntryPoint     $entryPoint            entryPoint
      */
-    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, LoggerInterface $logger, RequestSignatureEntryPoint $entryPoint)
+    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, LoggerInterface $logger = null, RequestSignatureEntryPoint $entryPoint = null)
     {
         $this->securityContext       = $securityContext;
         $this->authenticationManager = $authenticationManager;
@@ -53,6 +53,7 @@ class RequestSignatureListener implements ListenerInterface
 
         $request   = $event->getRequest();
         $parameter = $this->entryPoint->get('parameter');
+
         if (null !== $signature = $request->get($parameter)) {
 
             $token = new RequestSignatureToken();
@@ -68,11 +69,15 @@ class RequestSignatureListener implements ListenerInterface
 
                 if ($returnValue instanceof TokenInterface) {
                     return $this->securityContext->setToken($returnValue);
-                } elseif ($returnValue instanceof Response) {
+                }
+
+                if ($returnValue instanceof Response) {
                     return $event->setResponse($returnValue);
                 }
             } catch (AuthenticationException $e) {
-                $this->logger->info(sprintf('Authentication request failed: %s', $e->getMessage()));
+                if ($this->logger) {
+                    $this->logger->info(sprintf('Authentication request failed: %s', $e->getMessage()));
+                }
             }
         }
 

--- a/behat.yml
+++ b/behat.yml
@@ -1,0 +1,25 @@
+default:
+    suites:
+        default:
+            contexts:
+                - FeatureContext:
+                    signatureBuilder: @rezzza.security.request_signature.builder
+                    firewallContext: @rezzza.security.firewall.demo.context
+                - Behat\MinkExtension\Context\MinkContext
+
+    translation:
+        locale: en
+
+    extensions:
+        Behat\Symfony2Extension:
+            kernel:
+                bootstrap: features/bootstrap/app/autoload.php
+                path: features/bootstrap/app/AppKernel.php
+                class: AppKernel
+                env: test
+                debug: true
+        Behat\MinkExtension:
+            base_url:  'http://localhost:8888'
+            sessions:
+                default:
+                    goutte: ~

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,15 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": "2.*",
+        "symfony/security-bundle" : "~2.0",
         "doctrine/common": "~2.2"
     },
     "require-dev": {
-        "atoum/atoum": "*@dev"
+        "atoum/atoum": "*@dev",
+        "behat/behat": "~3.0",
+        "behat/symfony2-extension": "~2.0",
+        "behat/mink-extension": "~2.0",
+        "behat/mink-goutte-driver": "~1.1"
     },
     "autoload":     {
         "psr-0": { "Rezzza\\SecurityBundle": "" }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "target-dir": "Rezzza/SecurityBundle",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.1.x-dev"
+            "dev-master": "1.2.x-dev"
         }
     },
     "config": {

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -1,0 +1,59 @@
+<?php
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Gherkin\Node\PyStringNode;
+use Behat\Gherkin\Node\TableNode;
+
+use Behat\MinkExtension\Context\RawMinkContext;
+
+/**
+ * Defines application features from the specific context.
+ */
+class FeatureContext extends RawMinkContext implements Context, SnippetAcceptingContext
+{
+    private $signatureBuilder;
+
+    private $firewallContext;
+
+    public function __construct($signatureBuilder, $firewallContext)
+    {
+        $this->signatureBuilder = $signatureBuilder;
+        $this->firewallContext = $firewallContext;
+    }
+
+    /**
+     * @When I am on :url with good signature
+     */
+    public function iAmOnWithGoodSignature($url)
+    {
+        $this->visitPath(
+            $this->buildUrlSigned($url, time())
+        );
+    }
+
+    /**
+     * @When I am on :url with good signature but I wait :seconds seconds before perform request
+     */
+    public function iAmOnWithGoodSignatureButIWaitSecondsBeforePerformRequest($url, $seconds)
+    {
+        $url = $this->buildUrlSigned($url, time());
+
+        sleep($seconds);
+
+        $this->visitPath($url);
+    }
+
+    private function buildUrlSigned($url, $timestamp)
+    {
+        $this->firewallContext
+            ->set('request.method', 'GET')
+            ->set('request.host', 'localhost:8888')
+            ->set('request.path_info', $url)
+            ->set('request.signature_time', $timestamp)
+        ;
+        $signature = $this->signatureBuilder->build($this->firewallContext);
+
+        return sprintf('%s?_signature=%s&_signature_ttl=%s', $url, $signature, $timestamp);
+    }
+}

--- a/features/bootstrap/app/AppKernel.php
+++ b/features/bootstrap/app/AppKernel.php
@@ -1,0 +1,24 @@
+<?php
+
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Config\Loader\LoaderInterface;
+
+class AppKernel extends Kernel
+{
+    public function registerBundles()
+    {
+        $bundles = array(
+            new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+            new Symfony\Bundle\SecurityBundle\SecurityBundle(),
+            new Rezzza\SecurityBundle\RezzzaSecurityBundle(),
+            new Rezzza\Bundle\DemoBundle\DemoBundle
+        );
+
+        return $bundles;
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(__DIR__.'/config/config.yml');
+    }
+}

--- a/features/bootstrap/app/autoload.php
+++ b/features/bootstrap/app/autoload.php
@@ -1,0 +1,3 @@
+<?php
+$loader = require(__DIR__.'/../../../vendor/autoload.php');
+$loader->addPsr4('Rezzza\\Bundle\\', __DIR__.'/../bundle/');

--- a/features/bootstrap/app/config/config.yml
+++ b/features/bootstrap/app/config/config.yml
@@ -1,0 +1,22 @@
+imports:
+    - { resource: security.yml }
+#    - { resource: parameters.yml }
+
+framework:
+    secret: test_blah
+    router:
+        resource: "%kernel.root_dir%/config/routing.yml"
+        strict_requirements: "%kernel.debug%"
+    form: false
+    csrf_protection: true
+    validation: false
+    default_locale: en
+    trusted_proxies: ~
+    session: ~
+
+rezzza_security:
+    firewalls:
+        demo:
+            algorithm:         SHA1
+            secret:            MyS3cr3t
+            replay_protection: true

--- a/features/bootstrap/app/config/routing.yml
+++ b/features/bootstrap/app/config/routing.yml
@@ -1,0 +1,3 @@
+demo:
+    path:  /hello
+    defaults: { _controller: DemoBundle:Demo:hello }

--- a/features/bootstrap/app/config/security.yml
+++ b/features/bootstrap/app/config/security.yml
@@ -1,0 +1,20 @@
+security:
+    encoders:
+        Symfony\Component\Security\Core\User\User: plaintext
+
+    providers:
+        in_memory:
+            memory:
+                users:
+                    foo: { password: bar }
+    firewalls:
+        api:
+            pattern:   ^/.*
+            request_signature:
+                algorithm: SHA1
+                secret:    MyS3cr3t
+                parameter: _signature
+                replay_protection:
+                    enabled:   true
+                    lifetime:  1
+                    parameter: _signature_ttl

--- a/features/bootstrap/bundle/DemoBundle/Controller/DemoController.php
+++ b/features/bootstrap/bundle/DemoBundle/Controller/DemoController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rezzza\Bundle\DemoBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class DemoController extends Controller
+{
+    public function helloAction(Request $request)
+    {
+        return new Response('posay');
+    }
+}
+

--- a/features/bootstrap/bundle/DemoBundle/DemoBundle.php
+++ b/features/bootstrap/bundle/DemoBundle/DemoBundle.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rezzza\Bundle\DemoBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class DemoBundle extends Bundle
+{
+}

--- a/features/bootstrap/web/index.php
+++ b/features/bootstrap/web/index.php
@@ -1,0 +1,13 @@
+<?php
+
+use Symfony\Component\HttpFoundation\Request;
+
+require_once __DIR__.'/../app/autoload.php';
+require_once __DIR__.'/../app/AppKernel.php';
+
+$kernel = new AppKernel('test', false);
+$kernel->loadClassCache();
+$request = Request::createFromGlobals();
+$response = $kernel->handle($request);
+$response->send();
+$kernel->terminate($request, $response);

--- a/features/security.feature
+++ b/features/security.feature
@@ -1,0 +1,17 @@
+Feature: Check security config works
+    As a web user
+    In order to access protected resource
+    I should provide right signature
+
+    Scenario: No signature provided should lead to 403
+        When I am on "/hello"
+        Then the response status code should be 403
+
+    Scenario: Good signature provided should lead to 200
+        When I am on "/hello" with good signature
+        Then the response status code should be 200
+        And I should see "posay"
+
+    Scenario: Signature life expired should lead to 403
+        When I am on "/hello" with good signature but I wait 3 seconds before perform request
+        Then the response status code should be 403


### PR DESCRIPTION
It looks we don't need this hack. And we should not. 

But if finally it is needed, we should try to do a simple refactor by using a factory or something else to avoid this statement.
